### PR TITLE
Updated buildPlg to accept another function style

### DIFF
--- a/buildPlg.js
+++ b/buildPlg.js
@@ -49,7 +49,7 @@ function main(args) {
     // NOP
   }
 
-  var funcRegex = /function\s*([_a-zA-Z][_a-zA-Z0-9\$]*)(\(.*\))\s*\{/;
+  var funcRegex = /function\s*([_a-zA-Z][_a-zA-Z0-9\$]*)\s*(\(.*\))\s*\{?/;
   var moduleLineRegex = /^\s*\/\/\$module\(([\w]+\.mss)\)/;
 
   try {


### PR DESCRIPTION
This commit updates the buildPlg function-finding regex to accept function definitions with a space between the function name and the parameters, and to not require the closing '{' on the line (in styles where the curly brace is the first character on the next line.)